### PR TITLE
(feature) Add boolean fallback values to wrapper

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNLaunchDarklyModule.java
+++ b/android/src/main/java/com/reactlibrary/RNLaunchDarklyModule.java
@@ -105,8 +105,8 @@ public class RNLaunchDarklyModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void boolVariation(String flagName, Callback callback) {
-    Boolean variationResult = ldClient.boolVariation(flagName, false);
+  public void boolVariation(String flagName, Boolean fallback, Callback callback) {
+    Boolean variationResult = ldClient.boolVariation(flagName, fallback);
     callback.invoke(variationResult);
   }
 

--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ class LaunchDarkly {
     RNLaunchDarkly.configure(apiKey, options);
   }
 
-  boolVariation (featureName, callback) {
-    RNLaunchDarkly.boolVariation(featureName, callback);
+  boolVariation (featureName, fallback, callback) {
+    RNLaunchDarkly.boolVariation(featureName, fallback, callback);
   }
 
   stringVariation (featureName, fallback, callback) {

--- a/ios/RNLaunchDarkly.m
+++ b/ios/RNLaunchDarkly.m
@@ -61,9 +61,9 @@ RCT_EXPORT_METHOD(configure: (NSString *)apiKey options:(NSDictionary *)options)
     [[LDClient sharedInstance] start:config withUserBuilder:builder];
 }
 
-RCT_EXPORT_METHOD(boolVariation:(NSString*)flagName callback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(boolVariation:(NSString*)flagName fallback:(NSNumber*) callback:(RCTResponseSenderBlock)callback)
 {
-    BOOL showFeature = [[LDClient sharedInstance] boolVariation:flagName fallback:NO];
+    BOOL showFeature = [[LDClient sharedInstance] boolVariation:flagName fallback:fallback];
     callback(@[[NSNumber numberWithBool:showFeature]]);
 }
 

--- a/ios/RNLaunchDarkly.m
+++ b/ios/RNLaunchDarkly.m
@@ -61,7 +61,7 @@ RCT_EXPORT_METHOD(configure: (NSString *)apiKey options:(NSDictionary *)options)
     [[LDClient sharedInstance] start:config withUserBuilder:builder];
 }
 
-RCT_EXPORT_METHOD(boolVariation:(NSString*)flagName fallback:(NSNumber*) callback:(RCTResponseSenderBlock)callback)
+RCT_EXPORT_METHOD(boolVariation:(NSString*)flagName fallback:(BOOL)fallback callback:(RCTResponseSenderBlock)callback)
 {
     BOOL showFeature = [[LDClient sharedInstance] boolVariation:flagName fallback:fallback];
     callback(@[[NSNumber numberWithBool:showFeature]]);


### PR DESCRIPTION
## Link to the story

https://app.clubhouse.io/everymed/story/10349/aadeveloper-i-should-be-able-to-set-up-default-values-for-boolean-flags-in-launch-darkly

## Demo
Mobile app:
```typescript
  ['test-temp-feature-flag', <TFeature> {
    type: 'boolean',
    fallback: true,
  }],
```
LaunchDarkly:
![image](https://user-images.githubusercontent.com/301917/36259645-e2d20912-126f-11e8-8d5d-6af07922f1e7.png)


Android: https://drive.google.com/open?id=1gGAY5443OG8xL9reCsAfKh4N8babYjIX
iOS: https://drive.google.com/open?id=12P4qAGdEnHyZiUb_p4Fqrnb064nA4YDI